### PR TITLE
Update PrefCoroutines.kt

### DIFF
--- a/coroutines/src/main/java/com/afollestad/rxkprefs/coroutines/PrefCoroutines.kt
+++ b/coroutines/src/main/java/com/afollestad/rxkprefs/coroutines/PrefCoroutines.kt
@@ -31,6 +31,9 @@ fun <T : Any> Pref<T>.asFlow(): Flow<T> {
     addOnDestroyed { close() }
     addOnChanged { offer(get()) }
     offer(get())
-    awaitClose { cancel() }
+    awaitClose { 
+      destroy() 
+      cancel() 
+    }
   }
 }


### PR DESCRIPTION
seems destroy() was not invoked properly. onChanged array in RealPref.kt remains old listener(s) will cause JobCancellationException, For example when fragment created again

### Guidelines 

1. You must run the `spotlessApply` task before commiting, either through Android Studio or with `./gradlew spotlessApply`.
2. A PR should be focused and contained. If you are changing multiple unrelated things, they should be in separate PRs.
3. A PR should fix a bug or solve a problem - something that only you would use is not necessarily something that should be published.
4. Give your PR a detailed title and description - look over your code one last time before actually creating the PR. Give it a self-review.

**If you do not follow the guidelines, your PR will be rejected.**
